### PR TITLE
add support for tests running on postgresql

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,6 +37,10 @@ on:
         required: false
         type: string
         default: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+      DATABASE_CLIENT_VERSION:
+        description: The database client version to use. Currently only applies to PostgreSQL and has to be the same as or higher than the database image version.
+        required: false
+        type: string
       PHP_VERSION:
         description: The PHP version to execute the tests for.
         required: true
@@ -106,7 +110,7 @@ jobs:
         if: ${{ contains(inputs.DATABASE_IMAGE, 'postgres') }}
         uses: tj-actions/install-postgresql@v3
         with:
-          postgresql-version: 17
+          postgresql-version: ${{ inputs.DATABASE_CLIENT_VERSION }}
 
       - name: Get composer cache directory
         id: get-cache-dir

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,6 +12,11 @@ on:
         description: The name of the database.
         required: true
         type: string
+      DATABASE_PORT:
+        description: The port of the database.
+        required: false
+        type: string
+        default: '3306'
       DATABASE_OPTIONS:
         description: The options to use for the database, such as health check.
         required: false
@@ -55,7 +60,7 @@ jobs:
           POSTGRES_HOST_AUTH_METHOD: trust
           POSTGRES_DB: ${{ inputs.DATABASE_NAME }}
         ports:
-          - 3306
+          - ${{ inputs.DATABASE_PORT }}
         options: ${{ inputs.DATABASE_OPTIONS }}
 
     name: PHP ${{ inputs.PHP_VERSION }} with Laravel ${{ inputs.LARAVEL_VERSION }} (${{ inputs.DEPENDENCY_VERSION }})
@@ -101,4 +106,4 @@ jobs:
       - name: Execute tests
         run: ${{ inputs.TEST_COMMANDS }}
         env:
-          DB_PORT: ${{ job.services.database.ports[3306] }}
+          DB_PORT: ${{ job.services.database.ports[inputs.DATABASE_PORT] }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -103,6 +103,7 @@ jobs:
 
       # The GitHub runner PostgreSQL version is outdated, and will not work with databases using the latest PostgreSQL version.
       - name: Update PostgreSQL
+        if: ${{ contains(inputs.DATABASE_IMAGE, 'postgres') }}
         uses: tj-actions/install-postgresql@v3
         with:
           postgresql-version: 17

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,6 +17,21 @@ on:
         required: false
         type: string
         default: '3306'
+      DATABASE_CONNECTION:
+        description: The database connection to use.
+        required: false
+        type: string
+        default: mysql
+      DATABASE_HOST:
+        description: The host of the database.
+        required: false
+        type: string
+        default: 127.0.0.1
+      DATABASE_USERNAME:
+        description: The username to use for the database.
+        required: false
+        type: string
+        default: root
       DATABASE_OPTIONS:
         description: The options to use for the database, such as health check.
         required: false
@@ -113,3 +128,7 @@ jobs:
         run: ${{ inputs.TEST_COMMANDS }}
         env:
           DB_PORT: ${{ job.services.database.ports[inputs.DATABASE_PORT] }}
+          DB_CONNECTION: ${{ inputs.DATABASE_CONNECTION }}
+          DB_HOST: ${{ inputs.DATABASE_HOST }}
+          DB_DATABASE: ${{ inputs.DATABASE_NAME }}
+          DB_USERNAME: ${{ inputs.DATABASE_USERNAME }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -86,6 +86,12 @@ jobs:
           packages: ${{ inputs.LINUX_PACKAGES }}
           version: ${{ inputs.PHP_VERSION }}
 
+      # The GitHub runner PostgreSQL version is outdated, and will not work with databases using the latest PostgreSQL version.
+      - name: Update PostgreSQL
+        uses: tj-actions/install-postgresql@v3
+        with:
+          postgresql-version: 17
+
       - name: Get composer cache directory
         id: get-cache-dir
         run: echo "directory=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,6 +3,20 @@ name: Setup environment and execute tests for a Laravel project
 on:
   workflow_call:
     inputs:
+      DATABASE_IMAGE:
+        description: The Docker image to use for the database.
+        required: false
+        type: string
+        default: mysql:8.0
+      DATABASE_NAME:
+        description: The name of the database.
+        required: true
+        type: string
+      DATABASE_OPTIONS:
+        description: The options to use for the database, such as health check.
+        required: false
+        type: string
+        default: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
       PHP_VERSION:
         description: The PHP version to execute the tests for.
         required: true
@@ -13,10 +27,6 @@ on:
         type: string
       DEPENDENCY_VERSION:
         description: The dependency version to execute the tests for.
-        required: true
-        type: string
-      MYSQL_DATABASE:
-        description: The name of the MySQL database.
         required: true
         type: string
       TEST_COMMANDS:
@@ -35,14 +45,18 @@ jobs:
   execute-tests:
     runs-on: ubuntu-latest
     services:
-      mysql:
-        image: mysql:8.0
+      database:
+        image: ${{ inputs.DATABASE_IMAGE }}
         env:
+          # MySQL
           MYSQL_ALLOW_EMPTY_PASSWORD: yes
-          MYSQL_DATABASE: ${{ inputs.MYSQL_DATABASE }}
+          MYSQL_DATABASE: ${{ inputs.DATABASE_NAME }}
+          # PostgreSQL
+          POSTGRES_HOST_AUTH_METHOD: trust
+          POSTGRES_DB: ${{ inputs.DATABASE_NAME }}
         ports:
           - 3306
-        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+        options: ${{ inputs.DATABASE_OPTIONS }}
 
     name: PHP ${{ inputs.PHP_VERSION }} with Laravel ${{ inputs.LARAVEL_VERSION }} (${{ inputs.DEPENDENCY_VERSION }})
     steps:
@@ -87,4 +101,4 @@ jobs:
       - name: Execute tests
         run: ${{ inputs.TEST_COMMANDS }}
         env:
-          DB_PORT: ${{ job.services.mysql.ports[3306] }}
+          DB_PORT: ${{ job.services.database.ports[3306] }}

--- a/examples/tests-multiple-db-images.yml
+++ b/examples/tests-multiple-db-images.yml
@@ -10,9 +10,13 @@ on:
 
 env:
   MYSQL_IMAGE: mysql:8.0
+  MYSQL_PORT: 3306
   MYSQL_DB_OPTIONS: "--health-cmd=\"mysqladmin ping\" --health-interval=10s --health-timeout=5s --health-retries=3"
+  MYSQL_PHPUNIT_CONFIG: "phpunit-ci-mysql.xml.dist"
   POSTGRES_IMAGE: postgres:17
+  POSTGRES_PORT: 5432
   POSTGRES_DB_OPTIONS: "--health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 3"
+  POSTGRES_PHPUNIT_CONFIG: "phpunit-ci-postgres.xml.dist"
 
 jobs:
   # Environment variables are not available in the matrix context, so we have to define them as outputs.
@@ -21,9 +25,13 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       MYSQL_IMAGE: ${{ env.MYSQL_IMAGE }}
+      MYSQL_PORT: ${{ env.MYSQL_PORT }}
       MYSQL_DB_OPTIONS: ${{ env.MYSQL_DB_OPTIONS }}
+      MYSQL_PHPUNIT_CONFIG: ${{ env.MYSQL_PHPUNIT_CONFIG }}
       POSTGRES_IMAGE: ${{ env.POSTGRES_IMAGE }}
+      POSTGRES_PORT: ${{ env.POSTGRES_PORT }}
       POSTGRES_DB_OPTIONS: ${{ env.POSTGRES_DB_OPTIONS }}
+      POSTGRES_PHPUNIT_CONFIG: ${{ env.POSTGRES_PHPUNIT_CONFIG }}
     steps:
       # Placeholder because a job needs a step.
       - run: echo "null"
@@ -38,10 +46,14 @@ jobs:
       matrix:
         db-image: [ "${{ needs.prepare.outputs.MYSQL_IMAGE }}", "${{ needs.prepare.outputs.POSTGRES_IMAGE }}" ]
         db-options: [ "${{ needs.prepare.outputs.MYSQL_DB_OPTIONS }}", "${{ needs.prepare.outputs.POSTGRES_DB_OPTIONS }}" ]
-        php: [ 8.2, 8.3 ]
-        laravel: [ 11.* ]
+        php: [ 8.1, 8.2, 8.3 ]
+        laravel: [ 9.*, 10.*, 11.* ]
         dependency-version: [ prefer-stable ]
         exclude:
+          - php: 8.3
+            laravel: 9.*
+          - php: 8.1
+            laravel: 11.*
           - db-image: "${{ needs.prepare.outputs.MYSQL_IMAGE }}"
             db-options: "${{ needs.prepare.outputs.POSTGRES_DB_OPTIONS }}"
           - db-image: "${{ needs.prepare.outputs.POSTGRES_IMAGE }}"
@@ -49,9 +61,10 @@ jobs:
     with:
       DATABASE_IMAGE: ${{ matrix.db-image }}
       DATABASE_NAME: myproject_test
+      DATABASE_PORT: ${{ matrix.db-image == needs.prepare.outputs.MYSQL_IMAGE && needs.prepare.outputs.MYSQL_PORT || needs.prepare.outputs.POSTGRES_PORT }}
       DATABASE_OPTIONS: ${{ matrix.db-options }}
       PHP_VERSION: ${{ matrix.php }}
       LARAVEL_VERSION: ${{ matrix.laravel }}
       DEPENDENCY_VERSION: ${{ matrix.dependency-version }}
-#     TEST_COMMANDS: vendor/bin/phpunit -c phpunit-ci.xml.dist
-#     LINUX_PACKAGES: imagemagick jpegoptim optipng pngquant gifsicle webp ffmpeg
+      TEST_COMMANDS: vendor/bin/phpunit -c ${{ matrix.db-image == needs.prepare.outputs.MYSQL_IMAGE && needs.prepare.outputs.MYSQL_PHPUNIT_CONFIG || needs.prepare.outputs.POSTGRES_PHPUNIT_CONFIG }}
+#      LINUX_PACKAGES: imagemagick jpegoptim optipng pngquant gifsicle webp ffmpeg

--- a/examples/tests-multiple-db-images.yml
+++ b/examples/tests-multiple-db-images.yml
@@ -8,44 +8,13 @@ on:
   pull_request:
   workflow_dispatch:
 
-env:
-  MYSQL_IMAGE: mysql:8.0
-  MYSQL_PORT: 3306
-  MYSQL_DB_OPTIONS: "--health-cmd=\"mysqladmin ping\" --health-interval=10s --health-timeout=5s --health-retries=3"
-  MYSQL_PHPUNIT_CONFIG: "phpunit-ci-mysql.xml.dist"
-  POSTGRES_IMAGE: postgres:17
-  POSTGRES_PORT: 5432
-  POSTGRES_DB_OPTIONS: "--health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 3"
-  POSTGRES_PHPUNIT_CONFIG: "phpunit-ci-postgres.xml.dist"
-
 jobs:
-  # Environment variables are not available in the matrix context, so we have to define them as outputs.
-  prepare:
-    name: Prepare environment
-    runs-on: ubuntu-latest
-    outputs:
-      MYSQL_IMAGE: ${{ env.MYSQL_IMAGE }}
-      MYSQL_PORT: ${{ env.MYSQL_PORT }}
-      MYSQL_DB_OPTIONS: ${{ env.MYSQL_DB_OPTIONS }}
-      MYSQL_PHPUNIT_CONFIG: ${{ env.MYSQL_PHPUNIT_CONFIG }}
-      POSTGRES_IMAGE: ${{ env.POSTGRES_IMAGE }}
-      POSTGRES_PORT: ${{ env.POSTGRES_PORT }}
-      POSTGRES_DB_OPTIONS: ${{ env.POSTGRES_DB_OPTIONS }}
-      POSTGRES_PHPUNIT_CONFIG: ${{ env.POSTGRES_PHPUNIT_CONFIG }}
-    steps:
-      # Placeholder because a job needs a step.
-      - run: echo "null"
-
-  execute-tests:
-    name: Setup testing environment and execute tests
-    needs: prepare
-    # https://github.com/cybex-gmbh/github-workflows/blob/main/.github/workflows/tests.yml
-    uses: cybex-gmbh/github-workflows/.github/workflows/tests.yml@main
+  mysql-tests:
+    name: MySQL
+    # The matrix can optionally be extracted to its own reusable workflow to consolidate the configuration.
     strategy:
       fail-fast: true
       matrix:
-        db-image: [ "${{ needs.prepare.outputs.MYSQL_IMAGE }}", "${{ needs.prepare.outputs.POSTGRES_IMAGE }}" ]
-        db-options: [ "${{ needs.prepare.outputs.MYSQL_DB_OPTIONS }}", "${{ needs.prepare.outputs.POSTGRES_DB_OPTIONS }}" ]
         php: [ 8.1, 8.2, 8.3 ]
         laravel: [ 9.*, 10.*, 11.* ]
         dependency-version: [ prefer-stable ]
@@ -54,17 +23,38 @@ jobs:
             laravel: 9.*
           - php: 8.1
             laravel: 11.*
-          - db-image: "${{ needs.prepare.outputs.MYSQL_IMAGE }}"
-            db-options: "${{ needs.prepare.outputs.POSTGRES_DB_OPTIONS }}"
-          - db-image: "${{ needs.prepare.outputs.POSTGRES_IMAGE }}"
-            db-options: "${{ needs.prepare.outputs.MYSQL_DB_OPTIONS }}"
+    uses: cybex-gmbh/github-workflows/.github/workflows/tests.yml@main
     with:
-      DATABASE_IMAGE: ${{ matrix.db-image }}
       DATABASE_NAME: myproject_test
-      DATABASE_PORT: ${{ matrix.db-image == needs.prepare.outputs.MYSQL_IMAGE && needs.prepare.outputs.MYSQL_PORT || needs.prepare.outputs.POSTGRES_PORT }}
-      DATABASE_OPTIONS: ${{ matrix.db-options }}
       PHP_VERSION: ${{ matrix.php }}
       LARAVEL_VERSION: ${{ matrix.laravel }}
       DEPENDENCY_VERSION: ${{ matrix.dependency-version }}
-      TEST_COMMANDS: vendor/bin/phpunit -c ${{ matrix.db-image == needs.prepare.outputs.MYSQL_IMAGE && needs.prepare.outputs.MYSQL_PHPUNIT_CONFIG || needs.prepare.outputs.POSTGRES_PHPUNIT_CONFIG }}
+
+  postgres-tests:
+    name: PostgreSQL
+    # The matrix can optionally be extracted to its own reusable workflow to consolidate the configuration.
+    strategy:
+      fail-fast: true
+      matrix:
+        php: [ 8.1, 8.2, 8.3 ]
+        laravel: [ 9.*, 10.*, 11.* ]
+        dependency-version: [ prefer-stable ]
+        exclude:
+          - php: 8.3
+            laravel: 9.*
+          - php: 8.1
+            laravel: 11.*
+    uses: cybex-gmbh/github-workflows/.github/workflows/tests.yml@main
+    with:
+      DATABASE_IMAGE: postgres:17
+      DATABASE_NAME: myproject_test
+      DATABASE_PORT: 5432
+      DATABASE_USERNAME: postgres
+      DATABASE_CONNECTION: pgsql
+#      DATABASE_HOST: 127.0.0.1
+      DATABASE_OPTIONS: "--health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 3"
+      PHP_VERSION: ${{ matrix.php }}
+      LARAVEL_VERSION: ${{ matrix.laravel }}
+      DEPENDENCY_VERSION: ${{ matrix.dependency-version }}
+#      TEST_COMMANDS: vendor/bin/phpunit -c phpunit-ci.xml.dist
 #      LINUX_PACKAGES: imagemagick jpegoptim optipng pngquant gifsicle webp ffmpeg

--- a/examples/tests-multiple-db-images.yml
+++ b/examples/tests-multiple-db-images.yml
@@ -1,0 +1,57 @@
+name: Tests
+
+on:
+  push:
+    branches:
+      - main
+      - release/*
+  pull_request:
+  workflow_dispatch:
+
+env:
+  MYSQL_IMAGE: mysql:8.0
+  MYSQL_DB_OPTIONS: "--health-cmd=\"mysqladmin ping\" --health-interval=10s --health-timeout=5s --health-retries=3"
+  POSTGRES_IMAGE: postgres:17
+  POSTGRES_DB_OPTIONS: "--health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 3"
+
+jobs:
+  # Environment variables are not available in the matrix context, so we have to define them as outputs.
+  prepare:
+    name: Prepare environment
+    runs-on: ubuntu-latest
+    outputs:
+      MYSQL_IMAGE: ${{ env.MYSQL_IMAGE }}
+      MYSQL_DB_OPTIONS: ${{ env.MYSQL_DB_OPTIONS }}
+      POSTGRES_IMAGE: ${{ env.POSTGRES_IMAGE }}
+      POSTGRES_DB_OPTIONS: ${{ env.POSTGRES_DB_OPTIONS }}
+    steps:
+      # Placeholder because a job needs a step.
+      - run: echo "null"
+
+  execute-tests:
+    name: Setup testing environment and execute tests
+    needs: prepare
+    # https://github.com/cybex-gmbh/github-workflows/blob/main/.github/workflows/tests.yml
+    uses: cybex-gmbh/github-workflows/.github/workflows/tests.yml@main
+    strategy:
+      fail-fast: true
+      matrix:
+        db-image: [ "${{ needs.prepare.outputs.MYSQL_IMAGE }}", "${{ needs.prepare.outputs.POSTGRES_IMAGE }}" ]
+        db-options: [ "${{ needs.prepare.outputs.MYSQL_DB_OPTIONS }}", "${{ needs.prepare.outputs.POSTGRES_DB_OPTIONS }}" ]
+        php: [ 8.2, 8.3 ]
+        laravel: [ 11.* ]
+        dependency-version: [ prefer-stable ]
+        exclude:
+          - db-image: "${{ needs.prepare.outputs.MYSQL_IMAGE }}"
+            db-options: "${{ needs.prepare.outputs.POSTGRES_DB_OPTIONS }}"
+          - db-image: "${{ needs.prepare.outputs.POSTGRES_IMAGE }}"
+            db-options: "${{ needs.prepare.outputs.MYSQL_DB_OPTIONS }}"
+    with:
+      DATABASE_IMAGE: ${{ matrix.db-image }}
+      DATABASE_NAME: myproject_test
+      DATABASE_OPTIONS: ${{ matrix.db-options }}
+      PHP_VERSION: ${{ matrix.php }}
+      LARAVEL_VERSION: ${{ matrix.laravel }}
+      DEPENDENCY_VERSION: ${{ matrix.dependency-version }}
+#     TEST_COMMANDS: vendor/bin/phpunit -c phpunit-ci.xml.dist
+#     LINUX_PACKAGES: imagemagick jpegoptim optipng pngquant gifsicle webp ffmpeg

--- a/examples/tests.yml
+++ b/examples/tests.yml
@@ -20,9 +20,9 @@ jobs:
         laravel: [ 11.* ]
         dependency-version: [ prefer-stable ]
     with:
+      DATABASE_NAME: myproject_test
       PHP_VERSION: ${{ matrix.php }}
       LARAVEL_VERSION: ${{ matrix.laravel }}
       DEPENDENCY_VERSION: ${{ matrix.dependency-version }}
-      MYSQL_DATABASE: myproject_test
 #     TEST_COMMANDS: vendor/bin/phpunit -c phpunit-ci.xml.dist
 #     LINUX_PACKAGES: imagemagick jpegoptim optipng pngquant gifsicle webp ffmpeg

--- a/examples/tests.yml
+++ b/examples/tests.yml
@@ -24,5 +24,5 @@ jobs:
       PHP_VERSION: ${{ matrix.php }}
       LARAVEL_VERSION: ${{ matrix.laravel }}
       DEPENDENCY_VERSION: ${{ matrix.dependency-version }}
-#     TEST_COMMANDS: vendor/bin/phpunit -c phpunit-ci.xml.dist
-#     LINUX_PACKAGES: imagemagick jpegoptim optipng pngquant gifsicle webp ffmpeg
+#      TEST_COMMANDS: vendor/bin/phpunit -c phpunit-ci.xml.dist
+#      LINUX_PACKAGES: imagemagick jpegoptim optipng pngquant gifsicle webp ffmpeg


### PR DESCRIPTION
### NOTE: This includes a breaking change for all repositories currently using this workflow, as I have renamed the "MYSQL_DATABASE" input to "DATABASE_NAME". In my opinion this makes it more clear what it is and it's also generic.

You can now pass an image name and database options, such as a healthcheck, to the workflow. This will default to mysql if not passed.

Unfortunately, I have not found a possibility to dynamically pass environment variables to the service container which runs the db image. Therefore, when adding a different database we will probably have to add their specific environment variables. 


This feature is currently being implemented at https://github.com/cybex-gmbh/laravel-protector/pull/93 and can be tested there.